### PR TITLE
Fix: Add current date to release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Initial release
 
-### 1.0.1 - TBD
+### 1.0.1 - July 14, 2018
 
 - Bug fixes and corrections from code review
 


### PR DESCRIPTION
Add current date to release 1.0.1 in the change log

Resolves: N/a
See also: N/a